### PR TITLE
[FIX] filter framework type properties

### DIFF
--- a/Source/ContractModelsAttributeCheck/AttributeChecker.cs
+++ b/Source/ContractModelsAttributeCheck/AttributeChecker.cs
@@ -137,6 +137,7 @@ namespace ContractModelsAttributeCheck
             _ = ShouldSkipType(distinctTypeList, currentType) ||
                 SearchForTypesWhenItIsAnArray(currentType, distinctTypeList) ||
                 SearchForTypesWhenItIsAGenericType(currentType, distinctTypeList) ||
+                ShouldSkipFrameworkType(currentType) ||
                 SearchForTypesWhenItIsAClass(currentType, distinctTypeList);
         }
 

--- a/Tests/ContractModelsAttributeCheck.Test/AttributeCheckerTests.cs
+++ b/Tests/ContractModelsAttributeCheck.Test/AttributeCheckerTests.cs
@@ -97,6 +97,16 @@ namespace ContractModelsAttributeCheck.Test
         }
 
         [Fact]
+        public void Should_Not_Contain_Uri_Properties()
+        {
+            var results = _attributeChecker.CheckPropertiesForAttributes(typeof(TestClassWithSystemTypeProperty), _attributes);
+
+            var missingAttributes = results.Where(w => !w.HasRequiredAttribute).ToList();
+            missingAttributes.Count.Should().Be(1);
+
+        }
+
+        [Fact]
         public void Validate_DistinctTypeList()
         {
             var distinctTypeList = new DistinctTypeList();

--- a/Tests/ContractModelsAttributeCheck.Test/TestTypes/TestClassWithSystemTypeProperty.cs
+++ b/Tests/ContractModelsAttributeCheck.Test/TestTypes/TestClassWithSystemTypeProperty.cs
@@ -1,0 +1,10 @@
+﻿#nullable disable
+using System;
+
+namespace ContractModelsAttributeCheck.Test.TestTypes
+{
+    public class TestClassWithSystemTypeProperty
+    {
+        public Uri Url { get; set; }
+    }
+}

--- a/Tests/ContractModelsAttributeCheck.Test/TestTypes/TestClassWithoutAttributes.cs
+++ b/Tests/ContractModelsAttributeCheck.Test/TestTypes/TestClassWithoutAttributes.cs
@@ -1,4 +1,5 @@
 #nullable disable
+using System;
 using System.Collections.Generic;
 
 namespace ContractModelsAttributeCheck.Test.TestTypes


### PR DESCRIPTION
- framework types like uri get filtered out when they are used as an property
